### PR TITLE
Test - React.Profiler doesn't work with React 19 in Production build

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -26,6 +26,11 @@ module.exports = merge(common, {
       chunkFilename: '[id].css',
     }),
   ],
+  resolve: {
+    alias: {
+      'react-dom$': 'react-dom/profiling',
+    }
+  },
   
   module: {
     rules: [

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -2,7 +2,7 @@
 //import '@babel/polyfill';
 //import 'regenerator-runtime/runtime';
 
-import React from "react";
+import React, { Profiler } from "react";
 import ReactDOM from "react-dom";
 
 // Note: Using an Alias in Webpack
@@ -17,10 +17,13 @@ class App extends React.Component {
 	   
       return (
          <div>
-		  <Header />	 
-		    <Menu />
-		  <Bottom />
-		
+            <Profiler id="TEST" onRender={(_, phase) => {
+               console.log('phase', phase)
+            }}>
+               <Header />	 
+                  <Menu />
+               <Bottom />
+            </Profiler>
          </div>
       );
    }


### PR DESCRIPTION
Example of how enabling React.Profiler for a production build using webpack no longer works with React 19.